### PR TITLE
Allow concurrent same-FQDN DNS-01 challenges when using route53

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -333,6 +333,7 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 			DNS01Nameservers:        nameservers,
 			DNS01CheckRetryPeriod:   opts.ACMEDNS01Config.CheckRetryPeriod,
 			DNS01CheckAuthoritative: !opts.ACMEDNS01Config.RecursiveNameserversOnly,
+			DNS01PropagationTime:    opts.ACMEDNS01Config.PropagationTime,
 
 			AccountRegistry: acmeAccountRegistry,
 		},

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -166,6 +166,9 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 	fs.DurationVar(&c.ACMEDNS01Config.CheckRetryPeriod, "dns01-check-retry-period", c.ACMEDNS01Config.CheckRetryPeriod, ""+
 		"The duration the controller should wait between a propagation check. Despite the name, this flag is used to configure the wait period for both DNS01 and HTTP01 challenge propagation checks. For DNS01 challenges the propagation check verifies that a TXT record with the challenge token has been created. For HTTP01 challenges the propagation check verifies that the challenge token is served at the challenge URL."+
 		"This should be a valid duration string, for example 180s or 1h")
+	fs.DurationVar(&c.ACMEDNS01Config.PropagationTime, "dns01-propagation-time", c.ACMEDNS01Config.PropagationTime, ""+
+		"The duration the controller should wait after determining that an ACME dns entry exists."+
+		"This should be a valid duration string, for example 180s or 1h")
 
 	fs.BoolVar(&c.EnableCertificateOwnerRef, "enable-certificate-owner-ref", c.EnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -232,6 +232,10 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod time.Duration
+
+	// The duration the controller should wait after determining that an ACME dns entry exists.
+	// This should be a valid duration string, for example 180s or 1h
+	PropagationTime time.Duration
 }
 
 // TLSConfig configures how TLS certificates are sourced for serving.

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -82,6 +82,7 @@ var (
 	defaultDNS01RecursiveNameserversOnly = false
 	defaultDNS01RecursiveNameservers     = []string{}
 	defaultDNS01CheckRetryPeriod         = 10 * time.Second
+	defaultDNS01PropagationTime          = 60 * time.Second
 
 	defaultNumberOfConcurrentWorkers int32 = 5
 	defaultMaxConcurrentChallenges   int32 = 60
@@ -331,5 +332,9 @@ func SetDefaults_ACMEDNS01Config(obj *v1alpha1.ACMEDNS01Config) {
 
 	if obj.CheckRetryPeriod == time.Duration(0) {
 		obj.CheckRetryPeriod = defaultDNS01CheckRetryPeriod
+	}
+
+	if obj.PropagationTime == time.Duration(0) {
+		obj.PropagationTime = defaultDNS01PropagationTime
 	}
 }

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -148,6 +148,7 @@ func autoConvert_v1alpha1_ACMEDNS01Config_To_controller_ACMEDNS01Config(in *v1al
 		return err
 	}
 	out.CheckRetryPeriod = time.Duration(in.CheckRetryPeriod)
+	out.PropagationTime = time.Duration(in.PropagationTime)
 	return nil
 }
 
@@ -162,6 +163,7 @@ func autoConvert_controller_ACMEDNS01Config_To_v1alpha1_ACMEDNS01Config(in *cont
 		return err
 	}
 	out.CheckRetryPeriod = time.Duration(in.CheckRetryPeriod)
+	out.PropagationTime = time.Duration(in.PropagationTime)
 	return nil
 }
 

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -252,6 +252,10 @@ type ACMEDNS01Config struct {
 	// token is served at the challenge URL. This should be a valid duration
 	// string, for example 180s or 1h
 	CheckRetryPeriod time.Duration `json:"checkRetryPeriod,omitempty"`
+
+	// The duration the controller should wait after determining that an ACME dns entry exists.
+	// This should be a valid duration string, for example 180s or 1h
+	PropagationTime time.Duration `json:"propagationTime,omitempty"`
 }
 
 // TLSConfig configures how TLS certificates are sourced for serving.

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -268,6 +268,64 @@ func TestScheduleN(t *testing.T) {
 			},
 		},
 		{
+			name: "schedule parallel DNS-01 challenges when using route53",
+			n:    5,
+			challenges: []*cmacme.Challenge{
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("2"),
+				),
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("1"),
+				),
+				gen.Challenge("test3",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{},
+						},
+					}),
+					gen.SetChallengeCreationTimestamp(time.Unix(1, 1)),
+				),
+			},
+			expected: []*cmacme.Challenge{
+				gen.Challenge("test2",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("1"),
+				),
+				gen.Challenge("test1",
+					gen.SetChallengeDNSName("example.com"),
+					gen.SetChallengeType(cmacme.ACMEChallengeTypeDNS01),
+					gen.SetChallengeSolver(cmacme.ACMEChallengeSolver{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
+						},
+					}),
+					gen.SetChallengeKey("2"),
+				),
+			},
+		},
+		{
 			name: "don't schedule when total number of scheduled challenges exceeds global maximum",
 			n:    5,
 			challenges: append(

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -208,6 +208,9 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// The duration the controller should wait after determining that an ACME dns entry exists.
+	DNS01PropagationTime time.Duration
 }
 
 // IngressShimOptions contain default Issuer GVK config for the certificate-shim controllers.

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -123,9 +123,10 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 		return fmt.Errorf("DNS record for %q not yet propagated", ch.Spec.DNSName)
 	}
 
-	ttl := 60
-	log.V(logf.DebugLevel).Info("waiting DNS record TTL to allow the DNS01 record to propagate for domain", "ttl", ttl, "fqdn", fqdn)
-	time.Sleep(time.Second * time.Duration(ttl))
+	if s.DNS01PropagationTime > 0 {
+		log.V(logf.DebugLevel).Info("waiting DNS01 record to propagate for domain", "duration", s.DNS01PropagationTime, "fqdn", fqdn)
+		time.Sleep(s.DNS01PropagationTime)
+	}
 	log.V(logf.DebugLevel).Info("ACME DNS01 validation record propagated", "fqdn", fqdn)
 
 	return nil

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gen
 
 import (
+	"time"
+
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,6 +78,18 @@ func SetChallengeIssuer(o cmmeta.ObjectReference) ChallengeModifier {
 func SetChallengeDNSName(dnsName string) ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Spec.DNSName = dnsName
+	}
+}
+
+func SetChallengeSolver(s cmacme.ACMEChallengeSolver) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Solver = s
+	}
+}
+
+func SetChallengeCreationTimestamp(t time.Time) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.CreationTimestamp.Time = t
 	}
 }
 


### PR DESCRIPTION
This PR re-adds dns propagation concurrency that was lost when we reset the teleport branch. These changes are valid for v13. 